### PR TITLE
Fixed syntax issue in Build Spec

### DIFF
--- a/docs/01-linting.md
+++ b/docs/01-linting.md
@@ -25,7 +25,7 @@ version: 0.2
 
 phases:
     pre_build:
-        commands:
+      commands:
         - echo Copying hadolint.yml to the application directory
         - cp hadolint.yml $CODEBUILD_SRC_DIR_AppSource/hadolint.yml
         - echo Switching to the application directory
@@ -33,12 +33,12 @@ phases:
         - echo Pulling the hadolint docker image
         - docker pull hadolint/hadolint:v1.16.2
     build:
-        commands:
+      commands:
         - echo Build started on `date`
         - echo Scanning with Hadolint...          
         - result=`docker run --rm -i -v ${PWD}/hadolint.yml:/.hadolint.yaml hadolint/hadolint:v1.16.2 hadolint -f json - < Dockerfile`
     post_build:
-        commands:
+      commands:
         - echo $result
         - aws ssm put-parameter --name "codebuild-dockerfile-results" --type "String" --value "$result" --overwrite
         - echo Build completed on `date`

--- a/docs/02-secrets-scanning.md
+++ b/docs/02-secrets-scanning.md
@@ -18,24 +18,24 @@ version: 0.2
 phases:
   pre_build:
     commands:
-    - echo Setting CodeCommit Credentials
-    - git config --global credential.helper '!aws codecommit credential-helper $@'
-    - git config --global credential.UseHttpPath true
-    - echo Copying secrets_config.json to the application directory
-    - cp secrets_config.json $CODEBUILD_SRC_DIR_AppSource/secrets_config.json
-    - echo Switching to the application directory
-    - echo Installing pip and truffleHog
-    - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py 
-    - python get-pip.py 
-    - pip install truffleHog
+      - echo Setting CodeCommit Credentials
+      - git config --global credential.helper '!aws codecommit credential-helper $@'
+      - git config --global credential.UseHttpPath true
+      - echo Copying secrets_config.json to the application directory
+      - cp secrets_config.json $CODEBUILD_SRC_DIR_AppSource/secrets_config.json
+      - echo Switching to the application directory
+      - echo Installing pip and truffleHog
+      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py 
+      - python get-pip.py 
+      - pip install truffleHog
   build:
     commands:
-    - echo Build started on `date`
-    - echo Scanning with truffleHog...          
-    - trufflehog --regex --rules secrets_config.json --entropy=False "$APP_REPO_URL" 
+      - echo Build started on `date`
+      - echo Scanning with truffleHog...          
+      - trufflehog --regex --rules secrets_config.json --entropy=False "$APP_REPO_URL" 
   post_build:
     commands:
-    - echo Build completed on `date`
+      - echo Build completed on `date`
 ```
 
 ## Add the trufflehog regex configuration


### PR DESCRIPTION
Issue:

CodeBuild would fail with error:

```
Phase context status code: YAML_FILE_ERROR Message: wrong number of container tags, expected 1
```



Description of changes:

Fixed syntax for Build Spec files.

**Please ensure to update website via `mkdocs` **
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
