### PR TITLE
Fix/trufflehog

### DIFF
--- a/docs/02-secrets-scanning.md
+++ b/docs/02-secrets-scanning.md
@@ -24,15 +24,15 @@ phases:
     - echo Copying secrets_config.json to the application directory
     - cp secrets_config.json $CODEBUILD_SRC_DIR_AppSource/secrets_config.json
     - echo Switching to the application directory
-    - echo Installing pip and truffleHog
-    - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py 
-    - python get-pip.py 
-    - pip install truffleHog
+    - echo Installing truffleHog
+    - which pip3 && pip3 --version
+    - which python3 && python3 --version
+    - pip3 install 'truffleHog>=2.1.0,<3.0'
   build:
     commands:
     - echo Build started on `date`
-    - echo Scanning with truffleHog...          
-    - trufflehog --regex --rules secrets_config.json --entropy=False "$APP_REPO_URL" 
+    - echo Scanning with truffleHog...
+    - trufflehog --regex --rules secrets_config.json --entropy=False "$APP_REPO_URL"
   post_build:
     commands:
     - echo Build completed on `date`

--- a/docs/04-testing.md
+++ b/docs/04-testing.md
@@ -38,7 +38,8 @@ Now you can test your pipeline to see how your Pull Requests result with an imag
 1.	Within your Cloud9 IDE expand your **sample application** on the left side.
 2.  Open the **Dockerfile**.
 3.  Add a name to the Label line.
-4.  Push your commit.
+4.  Update the version for `sqlite-libs` to `3.31.1-r1`
+5.  Push your commit.
 
 ```bash
     cd /home/ec2-user/environment/sample-application

--- a/docs/04-testing.md
+++ b/docs/04-testing.md
@@ -38,7 +38,7 @@ Now you can test your pipeline to see how your Pull Requests result with an imag
 1.	Within your Cloud9 IDE expand your **sample application** on the left side.
 2.  Open the **Dockerfile**.
 3.  Add a name to the Label line.
-4.  Update the version for `sqlite-libs` to `3.31.1-r1`
+4.  Update the version for `sqlite-libs` to `3.30.1-r1`
 5.  Push your commit.
 
 ```bash


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-container-devsecops-workshop/issues/8
*Description of changes:*
Bind the Trufflehog version to >=2.1.0 and <3.0
Also, add instructions to update sqlite-libs to latest available version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
