### PR TITLE
Update vulnerabilities module

### DIFF
--- a/docs/03-vuln-scanning.md
+++ b/docs/03-vuln-scanning.md
@@ -18,11 +18,11 @@ version: 0.2
 phases: 
   pre_build: 
     commands:
-      - apt-get update && apt-get install -y python-dev jq
+      - apt-get update && apt-get install -y python3 python3-dev jq
       - docker pull anchore/engine-cli:v0.8.2
-      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py  
-      - python get-pip.py
-      - pip install awscli
+      - curl https://bootstrap.pypa.io/pip/3.4/get-pip.py -o get-pip.py   
+      - python3 get-pip.py
+      - python3 -m pip install awscli
       - $(aws ecr get-login --no-include-email)
       - ANCHORE_CMD="docker run -e ANCHORE_CLI_URL=$ANCHORE_CLI_URL -e ANCHORE_CLI_USER=$ANCHORE_CLI_USER -e ANCHORE_CLI_PASS=$ANCHORE_CLI_PASS anchore/engine-cli:v0.8.2 anchore-cli"
       - $ANCHORE_CMD registry add $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com awsauto awsauto --registry-type=awsecr || return 0

--- a/docs/04-testing.md
+++ b/docs/04-testing.md
@@ -304,8 +304,8 @@ Since the build fails the vulnerability analysis stage we need to fix the issue 
 
         **Fix**: Containers should be looked at as immutable and as such shouldn't be patched directly. Instead the vulernabilities should be fixed upstream in the source code and configuration of the image and then the image should be rebuilt and published.  This ensures that all new containers instantiated from the image don't include the vulnerabilities.
 
-        Update the affected package in Dockerfile:
-        Following the recommended **Remediation** update the `flask-cors` version to `3.0.9` in the Dockerfile.
+        Update the affected package in requirements.txt:
+        Following the recommended **Remediation** update the `flask-cors` version to `3.0.9` in requirements.txt.
 
         `flask-cors <= 3.0.9`
 
@@ -315,7 +315,7 @@ Commit your application source code changes:
 
 ```bash
 cd /home/ec2-user/environment/sample-application
-git add Dockerfile
+git add requirements.txt
 git commit -m "Update flask-cors version to fix CVE-2020-25032"
 git push -u origin development
 ```


### PR DESCRIPTION
*Issue #, if available:*

The vulnerability module uses python2 in the buildspec. This is no longer supported by pip so the build fails. There is also an error in the module doc regarding where the remediation occurs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
