### PR TITLE
fix for changing outdated codebuild image

### DIFF
--- a/anchore/anchore-fargate.yml
+++ b/anchore/anchore-fargate.yml
@@ -82,7 +82,7 @@ Resources:
           NO_ARTIFACTS
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:2.0
+        Image: aws/codebuild/standard:4.0-21.04.23
         PrivilegedMode: True
         Type: LINUX_CONTAINER
         ImagePullCredentialsType: CODEBUILD
@@ -233,7 +233,6 @@ Resources:
     Properties:
       AWSServiceName: ecs.amazonaws.com
       Description: Role to enable Amazon ECS to manage your cluster.
-
   Cluster:
     Type: AWS::ECS::Cluster
     DependsOn: EcsSlr

--- a/anchore/anchore-fargate.yml
+++ b/anchore/anchore-fargate.yml
@@ -233,6 +233,7 @@ Resources:
     Properties:
       AWSServiceName: ecs.amazonaws.com
       Description: Role to enable Amazon ECS to manage your cluster.
+
   Cluster:
     Type: AWS::ECS::Cluster
     DependsOn: EcsSlr

--- a/initial-pipeline/pipeline-setup.yml
+++ b/initial-pipeline/pipeline-setup.yml
@@ -1068,7 +1068,8 @@ Resources:
         Type: CODEPIPELINE
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/docker:18.09.0
+        Image: aws/codebuild/standard:5.0
+        PrivilegedMode: true
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: FAIL_WHEN


### PR DESCRIPTION
*Issue #, if available:*
"aws/codebuild/standard:2.0" is outdated and no longer available/maintained by AWS. Because of this, the CloudFormation fails to deploy with timeout error. Internally, ECS task creation fails and times out.

*Description of changes:*
changed "aws/codebuild/standard:2.0" to supported version "aws/codebuild/standard:4.0-21.04.23". Have tested this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
