### PR TITLE
Fetch anchore-engine from public-ecr

### DIFF
--- a/anchore/Dockerfile
+++ b/anchore/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/anchore/anchore-engine:v0.8.2
+FROM public.ecr.aws/l2l7h6f0/anchore-engine:v0.8.2
 
 COPY config.yaml /config/config.yaml


### PR DESCRIPTION
Fixes #26 

The problem described is caused by the failure of the `container-devsecops-wksp-anchore-build` execution during the deployment of `container-dso-wksp-AnchoreStack-XXXXXXXX` because of:

```
Step 1/2 : FROM docker.io/anchore/anchore-engine:v0.8.2
226	toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

*Description of changes:*
Fetch anchore-engine from public-ecr instead of docker.io

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
