### PR TITLE
Added support for Grype

### DIFF
--- a/grype/buildspec_vuln.yml
+++ b/grype/buildspec_vuln.yml
@@ -1,0 +1,23 @@
+version: 0.2
+
+phases: 
+  pre_build: 
+    commands:
+      - apt-get update 
+      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py  
+      - python get-pip.py
+      - pip install awscli
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+      - curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+      - echo "Copying grype.yml to the application directory"
+      - cp grype.yaml $CODEBUILD_SRC_DIR_AppSource/.grype.yaml
+  build: 
+    commands:
+      - IMAGE=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME
+      - docker build $CODEBUILD_SRC_DIR_AppSource -t $IMAGE
+      - docker push $IMAGE
+  post_build:
+    commands:
+      - /usr/local/bin/grype $IMAGE -c $CODEBUILD_SRC_DIR_AppSource/.grype.yaml > scan_results.json
+      - aws lambda invoke --function-name $FUNCTION_ARN --invocation-type RequestResponse --payload file://scan_results.json outfile
+      - /usr/local/bin/grype $IMAGE -c $CODEBUILD_SRC_DIR_AppSource/.grype.yaml -f $FAIL_WHEN

--- a/grype/grype.yaml
+++ b/grype/grype.yaml
@@ -1,0 +1,136 @@
+# enable/disable checking for application updates on startup
+# same as GRYPE_CHECK_FOR_APP_UPDATE env var
+check-for-app-update: true
+
+# upon scanning, if a severity is found at or above the given severity then the return code will be 1
+# default is unset which will skip this validation (options: negligible, low, medium, high, critical)
+# same as --fail-on ; GRYPE_FAIL_ON_SEVERITY env var
+fail-on-severity: ""
+
+# the output format of the vulnerability report (options: table, json, cyclonedx)
+# same as -o ; GRYPE_OUTPUT env var
+output: "json"
+
+# suppress all output (except for the vulnerability list)
+# same as -q ; GRYPE_QUIET env var
+quiet: false
+
+# write output report to a file (default is to write to stdout)
+# same as --file; GRYPE_FILE env var
+file: ""
+
+# a list of globs to exclude from scanning, for example:
+# exclude:
+#   - '/etc/**'
+#   - './out/**/*.json'
+# same as --exclude ; GRYPE_EXCLUDE env var
+exclude: []
+
+# os and/or architecture to use when referencing container images (e.g. "windows/armv6" or "arm64")
+# same as --platform; GRYPE_PLATFORM env var
+platform: ""
+
+# If using SBOM input, automatically generate CPEs when packages have none
+add-cpes-if-none: false
+
+# Explicitly specify a linux distribution to use as <distro>:<version> like alpine:3.10
+distro:
+
+external-sources:
+  enable: false
+  maven:
+    search-upstream-by-sha1: true
+    base-url: https://search.maven.org/solrsearch/select
+
+db:
+  # check for database updates on execution
+  # same as GRYPE_DB_AUTO_UPDATE env var
+  auto-update: true
+
+  # location to write the vulnerability database cache
+  # same as GRYPE_DB_CACHE_DIR env var
+  cache-dir: "$XDG_CACHE_HOME/grype/db"
+
+  # URL of the vulnerability database
+  # same as GRYPE_DB_UPDATE_URL env var
+  update-url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
+
+  # it ensures db build is no older than the max-allowed-built-age
+  # set to false to disable check
+  validate-age: true
+
+  # Max allowed age for vulnerability database,
+  # age being the time since it was built
+  # Default max age is 120h (or five days)
+  max-allowed-built-age: "120h"
+
+search:
+  # the search space to look for packages (options: all-layers, squashed)
+  # same as -s ; GRYPE_SEARCH_SCOPE env var
+  scope: "squashed"
+
+  # search within archives that do contain a file index to search against (zip)
+  # note: for now this only applies to the java package cataloger
+  # same as GRYPE_PACKAGE_SEARCH_INDEXED_ARCHIVES env var
+  indexed-archives: true
+
+  # search within archives that do not contain a file index to search against (tar, tar.gz, tar.bz2, etc)
+  # note: enabling this may result in a performance impact since all discovered compressed tars will be decompressed
+  # note: for now this only applies to the java package cataloger
+  # same as GRYPE_PACKAGE_SEARCH_UNINDEXED_ARCHIVES env var
+  unindexed-archives: false
+
+# options when pulling directly from a registry via the "registry:" scheme
+registry:
+  # skip TLS verification when communicating with the registry
+  # same as GRYPE_REGISTRY_INSECURE_SKIP_TLS_VERIFY env var
+  insecure-skip-tls-verify: false
+  # use http instead of https when connecting to the registry
+  # same as GRYPE_REGISTRY_INSECURE_USE_HTTP env var
+  insecure-use-http: false
+
+  # credentials for specific registries
+  auth:
+    #- # the URL to the registry (e.g. "docker.io", "localhost:5000", etc.)
+      # same as GRYPE_REGISTRY_AUTH_AUTHORITY env var
+    - authority: ""
+      # same as GRYPE_REGISTRY_AUTH_USERNAME env var
+      username: ""
+      # same as GRYPE_REGISTRY_AUTH_PASSWORD env var
+      password: ""
+      # note: token and username/password are mutually exclusive
+      # same as GRYPE_REGISTRY_AUTH_TOKEN env var
+      token: ""
+
+log:
+  # use structured logging
+  # same as GRYPE_LOG_STRUCTURED env var
+  structured: false
+
+  # the log level; note: detailed logging suppress the ETUI
+  # same as GRYPE_LOG_LEVEL env var
+  # Uses logrus logging levels: https://github.com/sirupsen/logrus#level-logging
+  level: "error"
+
+  # location to write the log file (default is not to have a log file)
+  # same as GRYPE_LOG_FILE env var
+  file: ""
+
+match:
+  # sets the matchers below to use cpes when trying to find 
+  # vulnerability matches. The stock matcher is the default
+  # when no primary matcher can be identified 
+  java:
+    using-cpes: true
+  python:
+    using-cpes: true
+  javascript:
+    using-cpes: true
+  ruby:
+    using-cpes: true
+  dotnet:
+    using-cpes: true
+  golang:
+    using-cpes: true
+  stock:
+    using-cpes: true

--- a/grype/initial-env-setup.yml
+++ b/grype/initial-env-setup.yml
@@ -1,0 +1,107 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: This AWS CloudFormation Template configures a new VPC and Pipeline Bucket that is used for the Container DevSecOps workshop. 
+
+Parameters:
+  
+  ResourceName:
+    Type: String
+    Default: devsecops-containers
+    AllowedValues: 
+      - devsecops-containers
+    Description: Prefix of Resources created for this workshop.
+
+  VpcCIDR:
+    Description: Please enter the IP range (CIDR notation) for this VPC
+    Type: String
+    Default: 10.192.0.0/16
+
+  PublicSubnet1CIDR:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone
+    Type: String
+    Default: 10.192.10.0/24
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Ref ResourceName
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Ref ResourceName
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      CidrBlock: !Ref PublicSubnet1CIDR
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceName} Public Subnet (AZ1)
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub ${ResourceName} Public Routes
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet1
+
+  ### CodePipeline - Artifact Bucket
+  PipelineBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'AES256'
+      BucketName: !Join [ '-', [ !Ref ResourceName, !Ref "AWS::AccountId", !Ref "AWS::Region", 'artifacts'  ] ]
+
+Outputs:
+  PipelineBucketARN:
+    Value: !GetAtt PipelineBucket.Arn
+    Export:
+      Name: InitialEnvStack:PipelineBucketArn
+  PipelineBucketName:
+    Value: !Ref PipelineBucket
+    Export:
+      Name: InitialEnvStack:PipelineBucketName
+  VPC:
+    Value: !GetAtt VPC.VpcId
+    Export:
+      Name: InitialEnvStack:VPC
+  PublicSubnet1:
+    Value: !GetAtt PublicSubnet1.SubnetId
+    Export: 
+      Name: InitialEnvStack:PublicSubnet1

--- a/grype/pipeline-setup.yml
+++ b/grype/pipeline-setup.yml
@@ -1,0 +1,1290 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: This AWS CloudFormation Template configures a pipeline that is used for the Container DevSecOps workshop.  
+
+Parameters:
+  
+  ResourceName:
+    Type: String
+    Default: devsecops-containers
+    AllowedValues: 
+      - devsecops-containers
+    Description: Prefix of Resources created for this workshop.
+
+  FailWhen:
+    Type: String
+    Default: High
+    AllowedValues: 
+      - Low
+      - Medium
+      - High
+      - Critical
+    Description: Threshold to fail the pipeline if app image has vulnerabilities
+
+  BucketName:
+    Type: String
+    Description: Source bucket for workshop CloudFormation yaml's
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups: 
+      - 
+        Label: 
+          default: "Resource and Notification Configuration"
+        Parameters: 
+          - ResourceName
+      - 
+        Label: 
+          default: "Fail Pipeline Threshold"
+        Parameters: 
+          - FailWhen
+
+    ParameterLabels: 
+      ResourceName:
+        default: "Resource Prefix"
+      FailWhen:
+        default: "Fail When"
+
+
+Mappings: {}
+
+Conditions: {}
+
+Resources:
+
+  ### Cloud9 IDE
+  Cloud9IDE:
+    Type: AWS::Cloud9::EnvironmentEC2
+    Properties:
+      Description: This is the IDE you will be using to complete the Container DevSecOps workshop.
+      InstanceType: t2.small
+      Name: !Join [ '-', [ !Ref ResourceName, 'ide'  ] ]
+      SubnetId: !ImportValue 'InitialEnvStack:PublicSubnet1'
+
+  # Send vuln findings to security hub
+  SendFindingsLambdaRole:
+    Type: AWS::IAM::Role
+    Properties: 
+      RoleName: !Join [ '-', [ !Ref ResourceName, 'lambda', 'send-findings'  ] ]
+      AssumeRolePolicyDocument: 
+        Version: 2012-10-17
+        Statement: 
+          - 
+            Effect: Allow
+            Principal: 
+              Service: 
+                - lambda.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      Policies: 
+        - 
+          PolicyName: Policy
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement: 
+              - 
+                Effect: Allow
+                Action:
+                  - securityhub:BatchImportFindings
+                Resource: '*'
+              - 
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+
+  Boto3LambdaLayer:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      LayerName: boto3-layer
+      Content:
+        S3Bucket: !Ref BucketName
+        S3Key: devsecops/layers/boto3.zip
+      CompatibleRuntimes:
+        - python3.9
+      LicenseInfo: Available under the MIT-0 license.
+
+  SendFindingsLambda:
+    DependsOn: SendFindingsLambdaRole
+    Type: AWS::Lambda::Function
+    Properties:
+      Layers:
+        - !Ref Boto3LambdaLayer
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'sendfindingstosechub'  ] ]
+      Description: Sends payload with vulnerabilities findings to Security Hub
+      Handler: index.lambda_handler
+      Role: !GetAtt SendFindingsLambdaRole.Arn
+      Environment:
+        Variables:
+          ACCOUNT_ID: !Ref AWS::AccountId
+          REGION: !Ref AWS::Region
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+          import os
+          import uuid
+          import datetime
+
+          client = boto3.client('securityhub')
+          account_id = os.environ['ACCOUNT_ID']
+          region = os.environ['REGION']
+          uuid = str(uuid.uuid4())
+          product_arn = "arn:aws:securityhub:{0}:{1}:product/{1}/default".format(region, account_id)
+
+          def chunker (seq, size):
+              return (seq[pos:pos + size] for pos in range(0, len(seq), size))
+
+          def lambda_handler(event, context):
+              if 'source' in event:
+                  image_id = event['source']['target']['repoDigests'][0].split('@')[1]
+                  image_tag = event['source']['target']['tags'][0]
+
+              if 'matches' in event:
+                  count = 0
+                  for group in chunker(event['matches'], 100):
+                      findings = []
+                      for vuln in group:
+                          try:
+                              desc = vuln["vulnerability"]["description"]
+                          except: 
+                              desc = "Description not provided."
+                          try: 
+                              sampleurl = str(vuln["relatedVulnerabilities"][0]["urls"][0])
+                          except:
+                              sampleurl = "Remediation URLs not provided."
+                          if vuln["vulnerability"]['severity'] == "Negligible" or vuln["vulnerability"]['severity'] == "Unknown":
+                              vuln["vulnerability"]['severity'] = "INFORMATIONAL"
+                          curr_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+                          finding = {
+                              "SchemaVersion": "2018-10-08",
+                              "Id": "{0}-{1}-Index-{2}".format(image_id, vuln["vulnerability"]["id"], str(count)), 
+                              "ProductArn": product_arn,
+                              "ProductFields": { "ProviderName": "Grype", "ProviderVersion": "0.49.0" },
+                              "GeneratorId": uuid,
+                              "AwsAccountId": account_id,
+                              "Types": [ "Software and Configuration Checks/Vulnerabilities/CVE" ],
+                              "CreatedAt": curr_time,
+                              "UpdatedAt": curr_time,
+                              "Severity": { "Label": vuln["vulnerability"]['severity'].upper() },
+                              "Title": "Vulnerability {0} found in {1} package".format(vuln["vulnerability"]["id"], vuln["artifact"]["name"]),
+                              "Description": desc,
+                              "SourceUrl": vuln["vulnerability"]["dataSource"],
+                              "Resources": [{
+                                      "Type": "Container",
+                                      "Id": image_tag,
+                                      "Details": { "Container": { "ImageId": image_id } }
+                              }],
+                              "Remediation": {
+                                  "Recommendation": {
+                                      "Text": "Refer to Urls for details",
+                                      "Url": sampleurl
+                                  }
+                              },
+                              "UserDefinedFields": {
+                                  "Namespace": vuln["vulnerability"]["namespace"],
+                                  "PackageName": vuln["artifact"]["name"],
+                                  "PackageVersion": vuln["artifact"]["version"],
+                                  "Locations": str(vuln["artifact"]["locations"][0])
+                              }
+                          }
+                          findings.append(finding)
+                          count += 1
+                      print(findings)
+                      import_response = client.batch_import_findings(Findings=findings)
+                      print(import_response)
+      Runtime: python3.9
+      Timeout: 900
+
+  ################### Repo Resources ###################
+
+  ### Application Repository
+  AppRepository: 
+    Type: AWS::CodeCommit::Repository
+    Properties: 
+      RepositoryDescription: Sample application repository to support the container devsecops workshop.
+      RepositoryName: !Join [ '-', [ !Ref ResourceName, 'app'  ] ]
+  
+  ### Configuration Repository
+  ConfigRepository: 
+    Type: AWS::CodeCommit::Repository
+    Properties: 
+      RepositoryDescription: Configuration repository to support the container devsecops workshop.
+      RepositoryName: !Join [ '-', [ !Ref ResourceName, 'config'  ] ]
+
+  ### Initial commit to sample application - Custom resource
+  RepositoryInitialCommit:
+    DependsOn: 
+      - AppRepository
+      - ConfigRepository
+      - LambdaRepositoryInitialCommit
+    Type: Custom::CustomResource
+    Properties:
+      ServiceToken: !GetAtt 'LambdaRepositoryInitialCommit.Arn'
+      Repo: !Join [ '-', [ !Ref ResourceName, 'app'  ] ]
+      RepoConfig: !Join [ '-', [ !Ref ResourceName, 'config'  ] ]
+
+  ### Initial commit to sample application - Lambda Role
+  LambdaRepositoryInitialCommitRole: 
+    Type: AWS::IAM::Role
+    Properties: 
+      RoleName: !Join [ '-', [ !Ref ResourceName, 'lambda', 'initial-commit'  ] ]
+      AssumeRolePolicyDocument: 
+        Version: 2012-10-17
+        Statement: 
+          - 
+            Effect: Allow
+            Principal: 
+              Service: 
+                - lambda.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      Policies: 
+        - 
+          PolicyName: InitialCommitPolicy
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement: 
+              - 
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - 
+                Effect: Allow
+                Action:
+                  - codecommit:*
+                Resource: '*'
+
+  ### Initial commit to sample application - Lambda
+  LambdaRepositoryInitialCommit:
+    DependsOn: LambdaRepositoryInitialCommitRole
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'initial-commit'  ] ]
+      Handler: "initial-commit.handler"
+      Description: "Creates initial commits to respository."
+      Role: !GetAtt 'LambdaRepositoryInitialCommitRole.Arn'
+      Code: 
+        S3Bucket: !Ref BucketName
+        S3Key: 'devsecops/containers/initial-commit.zip'
+      Runtime: "python3.9"
+      Timeout: "35"
+  
+  ### ECR Repository
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    Properties: 
+      RepositoryName: !Join [ '-', [ !Ref ResourceName, 'sample'  ] ]
+
+  ### Scratch ECR repository
+  ScratchRepository:
+    Type: AWS::ECR::Repository
+    Properties: 
+      RepositoryName: !Join [ '-', [ !Ref ResourceName, 'scratch'  ] ]
+
+  ### Feedback Loop - Pull Request
+  PREventRuleRole: 
+    Type: AWS::IAM::Role
+    Properties: 
+      RoleName: !Join [ '-', [ !Ref ResourceName, 'cloudwatch', 'pr'  ] ]
+      AssumeRolePolicyDocument: 
+        Version: 2012-10-17
+        Statement: 
+          - 
+            Effect: Allow
+            Principal: 
+              Service: 
+                - lambda.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      Policies: 
+        - 
+          PolicyName: PRPolicy
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement: 
+              - 
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - 
+                Effect: Allow
+                Action:
+                  - codepipeline:*
+                Resource: '*'
+
+  PREventRule:
+    DependsOn: LambdaPR
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Join [ '-', [ !Ref ResourceName, 'pr'  ] ]
+      Description: "Trigger notifications based on CodeCommit Pull Requests"
+      EventPattern:
+        source:
+          - "aws.codecommit"
+        detail-type:
+          - "CodeCommit Pull Request State Change"
+        resources:
+          - !GetAtt AppRepository.Arn
+        detail:
+          event:
+            - "pullRequestSourceBranchUpdated"
+            - "pullRequestCreated"
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt LambdaPR.Arn
+          Id: !Join [ '-', [ !Ref ResourceName, 'pr'  ] ]
+
+  LambdaPRCommentRole: 
+    Type: AWS::IAM::Role
+    Properties: 
+      RoleName: !Join [ '-', [ !Ref ResourceName, 'lambda', 'pr'  ] ]
+      AssumeRolePolicyDocument: 
+        Version: 2012-10-17
+        Statement: 
+          - 
+            Effect: Allow
+            Principal: 
+              Service: 
+                - lambda.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      Policies: 
+        - 
+          PolicyName: PRPolicy
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement: 
+              - 
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - 
+                Effect: Allow
+                Action:
+                  - codecommit:*
+                  - codebuild:*
+                  - codepipeline:StartPipelineExecution
+                  - ssm:DescribeParameters
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:DeleteParameters
+                Resource: '*'
+
+  LambdaPR:
+    DependsOn: LambdaPRCommentRole
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'pr'  ] ]
+      Description: "Adds an initial comment to the pull request."
+      Handler: "index.handler"
+      Environment:
+        Variables:
+          PREFIX: !Ref ResourceName
+      Role: !GetAtt 'LambdaPRCommentRole.Arn'
+      Code:
+        ZipFile: |
+          from __future__ import print_function
+          import datetime
+          import boto3
+          import os
+
+          codecommit_client = boto3.client('codecommit')
+          ssm = boto3.client('ssm')
+          codepipeline = boto3.client('codepipeline')
+
+          # Pipeline Name
+          pipeline = '%s-pipeline' % os.environ['PREFIX']
+
+          def handler(event, context):
+            # Log event
+            print(event)
+
+            # Pull request Event
+            if event['detail']['event'] in ['pullRequestSourceBranchUpdated', 'pullRequestCreated']:
+              
+              # Set variables
+              pull_request_id = event['detail']['pullRequestId']
+              repository_name = event['detail']['repositoryNames'][0]
+              source_commit = event['detail']['sourceCommit']
+              destination_commit = event['detail']['destinationCommit']
+
+              # Write commit details to SSM
+              ssm.put_parameter(
+                Name='prid',
+                Description='Pull Request ID',
+                Value=pull_request_id,
+                Overwrite=True,
+                Type='String'
+              )
+
+              ssm.put_parameter(
+                Name='repo',
+                Description='Repository Name',
+                Value=repository_name,
+                Overwrite=True,
+                Type='String'
+              )
+
+              ssm.put_parameter(
+                Name='sourceCommit',
+                Description='Source Commit',
+                Value=source_commit,
+                Overwrite=True,
+                Type='String'
+              )
+
+              ssm.put_parameter(
+                Name='destinationCommit',
+                Description='Destination Commit',
+                Value=destination_commit,
+                Overwrite=True,
+                Type='String'
+              )
+
+              # Add comments to PR
+              codecommit_client.post_comment_for_pull_request(
+                pullRequestId = pull_request_id,
+                repositoryName = repository_name,
+                beforeCommitId = source_commit,
+                afterCommitId = destination_commit,
+                content = '**Build started at {}.  Starting security testing.**'.format(datetime.datetime.utcnow().time())
+              )
+
+              codepipeline.start_pipeline_execution(
+                name=pipeline,
+              )
+            
+      Runtime: "python3.9"
+      Timeout: "35"
+      MemorySize: 128
+
+  PermissionForEventsToInvokeLambdaPR:
+    DependsOn: PREventRule
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'pr'  ] ]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt PREventRule.Arn
+
+  ################### FEEDBACK LOOPS ###################
+
+  ### Feedback Loop - Dockerfile Analysis CodeBuild
+
+  CBDFEventRule:
+    DependsOn: LambdaCBDF
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Join [ '-', [ !Ref ResourceName, 'codebuild-dockerfile'  ] ]
+      Description: "Triggers when builds fail/pass in CodeBuild for the static analysis of the Dockerfile."
+      EventPattern:
+        source:
+          - "aws.codebuild"
+        detail-type:
+          - "CodeBuild Build State Change"
+        detail:
+          build-status:
+            - "FAILED"
+            - "SUCCEEDED"
+          project-name:
+            - !Ref CodeBuildDFProject
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt LambdaCBDF.Arn
+          Id: !Join [ '-', [ !Ref ResourceName, 'codebuild-dockerfile'  ] ]
+
+  LambdaCBDF:
+    DependsOn: LambdaPRCommentRole
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-dockerfile'  ] ]
+      Description: "Adds a comment to the pull request regarding the success or failure of the Dockerfile static analysis codebuild."
+      Handler: "index.handler"
+      Environment:
+        Variables:
+          PREFIX: !Ref ResourceName
+          CODEBUILDDFPROJECT: !Ref CodeBuildDFProject
+          ASSETBUCKET: !Ref BucketName
+      Role: !GetAtt 'LambdaPRCommentRole.Arn'
+      Code:
+        ZipFile: |
+          from __future__ import print_function
+          import boto3
+          import os
+          import json
+
+          codecommit_client = boto3.client('codecommit')
+          ssm = boto3.client('ssm')
+          dfproject = os.environ['CODEBUILDDFPROJECT']
+          assetbucket = os.environ['ASSETBUCKET']
+
+          def handler(event, context):
+
+            # Log event
+            print(json.dumps(event))
+
+            # Get PR Details
+            pull_request_id = ssm.get_parameter(
+              Name='prid'
+            )
+
+            repository_name = ssm.get_parameter(
+              Name='repo'
+            )
+
+            source_commit = ssm.get_parameter(
+              Name='sourceCommit'
+            )
+
+            destination_commit = ssm.get_parameter(
+              Name='destinationCommit'
+            )
+
+            build_results = ssm.get_parameter(
+              Name='codebuild-dockerfile-results'
+            )
+
+            if event['detail']['project-name'] in [dfproject]:
+              build_results = json.loads(build_results['Parameter']['Value'])
+              # Add Errors
+              errors = '## Static Analysis - Dockerfile Configuration (using Hadolint)\n'
+              if not build_results:
+                errors = errors + 'No Misconfigurations!'
+              else:
+                for i in build_results:
+                  errors = errors + '* **%s** (%s): %s \n' % (i['code'], i['level'], i['message'])
+              for phase in event['detail']['additional-information']['phases']:
+                if phase.get('phase-status') == 'FAILED':
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/failing.svg'.format(assetbucket, event['region'])
+                    content = '![Failing]({0} "Failing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+                    break
+                else:
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/passing.svg'.format(assetbucket, event['region'])
+                    content = '![Passing]({0} "Passing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+
+            codecommit_client.post_comment_for_pull_request(
+              pullRequestId = pull_request_id['Parameter']['Value'],
+              repositoryName = repository_name['Parameter']['Value'],
+              beforeCommitId = source_commit['Parameter']['Value'],
+              afterCommitId = destination_commit['Parameter']['Value'],
+              content = content
+            )
+
+            ssm.delete_parameter(
+              Name='codebuild-dockerfile-results'
+            )
+      Runtime: "python3.9"
+      Timeout: "35"
+      MemorySize: 128
+
+  PermissionForEventsToInvokeLambdaCBDF:
+    DependsOn: CBDFEventRule
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-dockerfile'  ] ]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CBDFEventRule.Arn
+
+  ### Feedback Loop - Secrets Scanning CodeBuild
+
+  CBSCEventRule:
+    DependsOn: LambdaCBSC
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Join [ '-', [ !Ref ResourceName, 'codebuild-secrets'  ] ]
+      Description: "Triggers when builds fail/pass in CodeBuild for the secrets analysis."
+      EventPattern:
+        source:
+          - "aws.codebuild"
+        detail-type:
+          - "CodeBuild Build State Change"
+        detail:
+          build-status:
+            - "FAILED"
+            - "SUCCEEDED"
+          project-name:
+            - !Ref CodeBuildSecretsProject
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt LambdaCBSC.Arn
+          Id: !Join [ '-', [ !Ref ResourceName, 'codebuild-secrets'  ] ]
+
+  LambdaCBSC:
+    DependsOn: LambdaPRCommentRole
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-secrets'  ] ]
+      Description: "Adds a comment to the pull request regarding the success or failure of the secrets analysis codebuild."
+      Handler: "index.handler"
+      Environment:
+        Variables:
+          PREFIX: !Ref ResourceName
+          CODEBUILDSCPROJECT: !Ref CodeBuildSecretsProject
+          ASSETBUCKET: !Ref BucketName
+      Role: !GetAtt 'LambdaPRCommentRole.Arn'
+      Code:
+        ZipFile: |
+          from __future__ import print_function
+          import boto3
+          import os
+          import json
+
+          codecommit_client = boto3.client('codecommit')
+          ssm = boto3.client('ssm')
+          scproject = os.environ['CODEBUILDSCPROJECT']
+          assetbucket = os.environ['ASSETBUCKET']
+
+          def handler(event, context):
+
+            # Log event
+            print(json.dumps(event))
+
+            # Get PR Details
+            pull_request_id = ssm.get_parameter(
+              Name='prid'
+            )
+
+            repository_name = ssm.get_parameter(
+              Name='repo'
+            )
+
+            source_commit = ssm.get_parameter(
+              Name='sourceCommit'
+            )
+
+            destination_commit = ssm.get_parameter(
+              Name='destinationCommit'
+            )
+
+            if event['detail']['project-name'] in [scproject]:
+              
+              # Add Errors
+              errors = '## Static Analysis - Secrets Scanning  (using truffleHog)\n'
+              if event['detail']['build-status'] == 'SUCCEEDED':
+                errors = errors + 'No secrets found!'
+              else:
+                errors = errors + 'Secrets found! Please review the logs and remove any sensitive data.'
+              for phase in event['detail']['additional-information']['phases']:
+                if phase.get('phase-status') == 'FAILED':
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/failing.svg'.format(assetbucket, event['region'])
+                    content = '![Failing]({0} "Failing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+                    break
+                else:
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/passing.svg'.format(assetbucket, event['region'])
+                    content = '![Passing]({0} "Passing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+
+            codecommit_client.post_comment_for_pull_request(
+              pullRequestId = pull_request_id['Parameter']['Value'],
+              repositoryName = repository_name['Parameter']['Value'],
+              beforeCommitId = source_commit['Parameter']['Value'],
+              afterCommitId = destination_commit['Parameter']['Value'],
+              content = content
+            )
+      Runtime: "python3.9"
+      Timeout: "35"
+      MemorySize: 128
+
+  PermissionForEventsToInvokeLambdaCBSC:
+    DependsOn: CBSCEventRule
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-secrets'  ] ]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CBSCEventRule.Arn
+  
+  ### Feedback Loop - Vunerability Scanning CodeBuild
+
+  CBVCEventRule:
+    DependsOn: LambdaCBVC
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Join [ '-', [ !Ref ResourceName, 'codebuild-vulnerability'  ] ]
+      Description: "Triggers when builds fail/pass in CodeBuild for the vulnerability scanning."
+      EventPattern:
+        source:
+          - "aws.codebuild"
+        detail-type:
+          - "CodeBuild Build State Change"
+        detail:
+          build-status:
+            - "FAILED"
+            - "SUCCEEDED"
+          project-name:
+            - !Ref CodeBuildVulnProject
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt LambdaCBVC.Arn
+          Id: !Join [ '-', [ !Ref ResourceName, 'codebuild-vulnerability'  ] ]
+
+  LambdaCBVC:
+    DependsOn: LambdaPRCommentRole
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-vulnerability'  ] ]
+      Description: "Adds a comment to the pull request regarding the success or failure of the vulnerability scanning codebuild."
+      Handler: "index.handler"
+      Environment:
+        Variables:
+          PREFIX: !Ref ResourceName
+          CODEBUILDVCPROJECT: !Ref CodeBuildVulnProject
+          ASSETBUCKET: !Ref BucketName
+      Role: !GetAtt 'LambdaPRCommentRole.Arn'
+      Code:
+        ZipFile: |
+          from __future__ import print_function
+          import boto3
+          import os
+          import json
+
+          codecommit_client = boto3.client('codecommit')
+          ssm = boto3.client('ssm')
+          vcproject = os.environ['CODEBUILDVCPROJECT']
+          assetbucket = os.environ['ASSETBUCKET']
+
+          def handler(event, context):
+
+            # Log event
+            print(json.dumps(event))
+
+            # Get PR Details
+            pull_request_id = ssm.get_parameter(
+              Name='prid'
+            )
+
+            repository_name = ssm.get_parameter(
+              Name='repo'
+            )
+
+            source_commit = ssm.get_parameter(
+              Name='sourceCommit'
+            )
+
+            destination_commit = ssm.get_parameter(
+              Name='destinationCommit'
+            )
+
+            sec_hub = 'https://%s.console.aws.amazon.com/securityhub/' % event['region'] 
+            if event['detail']['project-name'] in [vcproject]:
+              # Add Errors
+              errors = '## Vulnerability Scanning (using Grype)\n'
+              if event['detail']['build-status'] == 'SUCCEEDED':
+                errors = errors + 'No vulnerabilities that meet or exceed the threshold!  Please manage all other vulnerabilities in [Security Hub](%s).' % sec_hub
+              else:
+                errors = errors + 'Findings found! Please review the logs and fix the vulnerabilities.'
+              for phase in event['detail']['additional-information']['phases']:
+                if phase.get('phase-status') == 'FAILED':
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/failing.svg'.format(assetbucket, event['region'])
+                    content = '![Failing]({0} "Failing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+                    break
+                else:
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/passing.svg'.format(assetbucket, event['region'])
+                    content = '![Passing]({0} "Passing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+
+            codecommit_client.post_comment_for_pull_request(
+              pullRequestId = pull_request_id['Parameter']['Value'],
+              repositoryName = repository_name['Parameter']['Value'],
+              beforeCommitId = source_commit['Parameter']['Value'],
+              afterCommitId = destination_commit['Parameter']['Value'],
+              content = content
+            )
+      Runtime: "python3.9"
+      Timeout: "35"
+      MemorySize: 128
+
+  PermissionForEventsToInvokeLambdaCBVC:
+    DependsOn: CBVCEventRule
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-vulnerability'  ] ]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CBVCEventRule.Arn
+  
+  ### Feedback Loop - Publish Image
+
+  CBPUEventRule:
+    DependsOn: LambdaCBPU
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Join [ '-', [ !Ref ResourceName, 'codebuild-publish'  ] ]
+      Description: "Triggers when builds fail/pass in CodeBuild for the Build and Push Stage."
+      EventPattern:
+        source:
+          - "aws.codebuild"
+        detail-type:
+          - "CodeBuild Build State Change"
+        detail:
+          build-status:
+            - "FAILED"
+            - "SUCCEEDED"
+          project-name:
+            - !Ref CodeBuildPublishProject
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt LambdaCBPU.Arn
+          Id: !Join [ '-', [ !Ref ResourceName, 'codebuild-publish'  ] ]
+
+  LambdaCBPU:
+    DependsOn: LambdaPRCommentRole
+    Type: "AWS::Lambda::Function"
+    Properties: 
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-publish'  ] ]
+      Description: "Adds a comment to the pull request regarding the success or failure of the publish codebuild project."
+      Handler: "index.handler"
+      Environment:
+        Variables:
+          PREFIX: !Ref ResourceName
+          CODEBUILDPUPROJECT: !Ref CodeBuildPublishProject
+          ASSETBUCKET: !Ref BucketName
+      Role: !GetAtt 'LambdaPRCommentRole.Arn'
+      Code:
+        ZipFile: |
+          from __future__ import print_function
+          import boto3
+          import os
+          import json
+
+          codecommit_client = boto3.client('codecommit')
+          ssm = boto3.client('ssm')
+          puproject = os.environ['CODEBUILDPUPROJECT']
+          assetbucket = os.environ['ASSETBUCKET']
+
+          def handler(event, context):
+
+            # Log event
+            print(json.dumps(event))
+
+            # Get PR Details
+            pull_request_id = ssm.get_parameter(
+              Name='prid'
+            )
+
+            repository_name = ssm.get_parameter(
+              Name='repo'
+            )
+
+            source_commit = ssm.get_parameter(
+              Name='sourceCommit'
+            )
+
+            destination_commit = ssm.get_parameter(
+              Name='destinationCommit'
+            )
+
+            sec_hub = 'https://%s.console.aws.amazon.com/securityhub/' % event['region'] 
+            if event['detail']['project-name'] in [puproject]:
+              errors = '## Image Build and Push\n'
+              if event['detail']['build-status'] == 'SUCCEEDED':
+                errors = errors + 'Image has successfully been published to the [AWS ECR repository](https://{0}.console.aws.amazon.com/ecr/repositories/devsecops-containers-sample/).  The Pull Request has been merged and closed.'.format(event['region'])
+              else:
+                errors = errors + 'Image has failed to build.  Please review the logs'
+              for phase in event['detail']['additional-information']['phases']:
+                if phase.get('phase-status') == 'FAILED':
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/failing.svg'.format(assetbucket, event['region'])
+                    content = '![Failing]({0} "Failing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+                    break
+                else:
+                    badge = 'https://{0}.s3.{1}.amazonaws.com/devsecops/containers/badges/passing.svg'.format(assetbucket, event['region'])
+                    content = '![Passing]({0} "Passing") - See the [Logs]({1})\n'.format(badge, event['detail']['additional-information']['logs']['deep-link'])
+                    content = content + errors
+
+            codecommit_client.post_comment_for_pull_request(
+              pullRequestId = pull_request_id['Parameter']['Value'],
+              repositoryName = repository_name['Parameter']['Value'],
+              beforeCommitId = source_commit['Parameter']['Value'],
+              afterCommitId = destination_commit['Parameter']['Value'],
+              content = content
+            )
+
+            # Merge Pull Request
+            codecommit_client.merge_pull_request_by_fast_forward(
+              pullRequestId=pull_request_id['Parameter']['Value'],
+              repositoryName=repository_name['Parameter']['Value']
+            )
+
+            # Delete pipeline parameters
+            ssm.delete_parameters(
+              Names=[
+                  'prid',
+                  'repo',
+                  'sourceCommit',
+                  'destinationCommit'
+              ]
+            )
+      Runtime: "python3.9"
+      Timeout: "35"
+      MemorySize: 128
+
+  PermissionForEventsToInvokeLambdaCBPU:
+    DependsOn: CBPUEventRule
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName: !Join [ '-', [ !Ref ResourceName, 'codebuild-publish'  ] ]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CBPUEventRule.Arn
+
+  ################### Pipeline ###################
+
+  # ### CodePipeline - Artifact Bucket
+  # PipelineBucket:
+  #   Type: AWS::S3::Bucket
+  #   Properties:
+  #     BucketEncryption:
+  #       ServerSideEncryptionConfiguration:
+  #         - ServerSideEncryptionByDefault:
+  #             SSEAlgorithm: 'AES256'
+  #     BucketName: !Join [ '-', [ !Ref ResourceName, !Ref "AWS::AccountId", !Ref "AWS::Region", 'artifacts'  ] ]
+
+  ### CodePipeline - Service Role
+  CodePipelineRole: 
+    Type: AWS::IAM::Role
+    Properties: 
+      RoleName: !Join [ '-', [ !Ref ResourceName, 'codepipeline', 'service'  ] ]
+      AssumeRolePolicyDocument: 
+        Version: 2012-10-17
+        Statement: 
+          - 
+            Effect: Allow
+            Principal: 
+              Service: 
+                - codepipeline.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      Policies: 
+        - 
+          PolicyName: ServicePolicy
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement: 
+              - 
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - 
+                Effect: Allow
+                Action:
+                  - codecommit:*
+                Resource: '*'
+              -
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:ListObject
+                Resource: [!Join [ '', [ !ImportValue 'InitialEnvStack:PipelineBucketArn', '/*'  ] ], !ImportValue 'InitialEnvStack:PipelineBucketArn' ]
+              -
+                Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuilds
+                Resource: '*'
+  
+  ### CodePipeline
+  CodePipeline:
+    DependsOn: CodePipelineRole
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      ArtifactStore:
+        Type: S3
+        Location: !ImportValue 'InitialEnvStack:PipelineBucketName'
+      RoleArn: !GetAtt 'CodePipelineRole.Arn'
+      Name: !Join [ '-', [ !Ref ResourceName, 'pipeline'  ] ]
+      Stages:
+        - Name: PullRequest
+          Actions:
+            - Name: AppSource
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeCommit
+              OutputArtifacts:
+                - Name: "AppSource"
+              Configuration:
+                BranchName: "development"
+                RepositoryName: !Join [ '-', [ !Ref ResourceName, 'app'  ] ]
+                PollForSourceChanges: false
+              RunOrder: 1
+            - Name: ConfigSource
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeCommit
+              OutputArtifacts:
+                - Name: "ConfigSource"
+              Configuration:
+                BranchName: "master"
+                RepositoryName: !Join [ '-', [ !Ref ResourceName, 'config'  ] ]
+                PollForSourceChanges: false
+              RunOrder: 1
+        - Name: 'StaticAnalysis-DockerfileConfiguration'
+          Actions:
+            - Name: Validation
+              ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Version: 1
+                  Provider: CodeBuild
+              OutputArtifacts:
+                - Name: "DFAppSourceOutput"
+                - Name: "DFConfigSourceOutput"
+              InputArtifacts:
+                - Name: "AppSource"
+                - Name: "ConfigSource"
+              Configuration:
+                  ProjectName: !Ref CodeBuildDFProject
+                  PrimarySource: "ConfigSource"
+              RunOrder: 1
+        - Name: 'StaticAnalysis-Secrets'
+          Actions:
+            - Name: Validation
+              ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Version: 1
+                  Provider: CodeBuild
+              OutputArtifacts:
+                - Name: "SecretsAppSourceOutput"
+                - Name: "SecretsConfigSourceOutput"
+              InputArtifacts:
+                - Name: "AppSource"
+                - Name: "ConfigSource"
+              Configuration:
+                  ProjectName: !Ref CodeBuildSecretsProject
+                  PrimarySource: "ConfigSource"
+              RunOrder: 1
+        - Name: 'VulnerabilityAnalysis'
+          Actions:
+            - Name: VulnerabilityScan
+              ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Version: 1
+                  Provider: CodeBuild
+              OutputArtifacts:
+                - Name: "VulnAppSourceOutput"
+                - Name: "VulnConfigSourceOutput"
+              InputArtifacts:
+                - Name: "AppSource"
+                - Name: "ConfigSource"
+              Configuration:
+                  ProjectName: !Ref CodeBuildVulnProject
+                  PrimarySource: "ConfigSource"
+              RunOrder: 1
+        - Name: 'PublishImage'
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Version: 1
+                  Provider: CodeBuild
+              OutputArtifacts:
+                - Name: "PushAppSourceOutput"
+                - Name: "PushConfigSourceOutput"
+              InputArtifacts:
+                - Name: "AppSource"
+                - Name: "ConfigSource"
+              Configuration:
+                  ProjectName: !Ref CodeBuildPublishProject
+                  PrimarySource: "ConfigSource"
+              RunOrder: 1
+
+  ################### CodeBuild Projects ###################
+
+  #### CodeBuild Dockerfile Analysis ####
+
+  ### CodeBuild Service Role
+  CodeBuildRole: 
+    Type: AWS::IAM::Role
+    Properties: 
+      RoleName: !Join [ '-', [ !Ref ResourceName, 'codebuild', 'service'  ] ]
+      AssumeRolePolicyDocument: 
+        Version: 2012-10-17
+        Statement: 
+          - 
+            Effect: Allow
+            Principal: 
+              Service: 
+                - codebuild.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      Policies: 
+        - 
+          PolicyName: ServicePolicy
+          PolicyDocument: 
+            Version: 2012-10-17
+            Statement: 
+              - 
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - 
+                Effect: Allow
+                Action:
+                  - codecommit:*
+                  - ssm:DescribeParameters
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:PutParameter
+                Resource: '*'
+              -
+                Effect: Allow
+                Action:
+                  - ecr:*
+                Resource: '*'
+              -
+                Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                  - lambda:InvokeAsync
+                Resource: !GetAtt SendFindingsLambda.Arn
+              -
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:ListObject
+                Resource: !Join [ '', [ !ImportValue 'InitialEnvStack:PipelineBucketArn', '/*'  ] ]
+
+  ### CodeBuild Project - Dockerfile Analysis
+  CodeBuildDFProject:
+    DependsOn: CodeBuildRole
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: 'BUILD_GENERAL1_SMALL'
+        Image: aws/codebuild/docker:18.09.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: !Ref "AWS::AccountId"
+      Name: !Join [ '-', [ !Ref ResourceName, 'build', 'dockerfile'  ] ]
+      ServiceRole: !GetAtt 'CodeBuildRole.Arn'
+      Source: 
+        Type: CODEPIPELINE
+        BuildSpec: buildspec_dockerfile.yml
+
+  #### CodeBuild Project - Secrets Analysis ####
+  CodeBuildSecretsProject:
+    DependsOn: CodeBuildRole
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: 'BUILD_GENERAL1_SMALL'
+        Image: aws/codebuild/docker:18.09.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: !Ref "AWS::AccountId"
+          - Name: APP_REPO_URL
+            Type: PLAINTEXT
+            Value: !GetAtt AppRepository.CloneUrlHttp
+      Name: !Join [ '-', [ !Ref ResourceName, 'build', 'secrets'  ] ]
+      ServiceRole: !GetAtt 'CodeBuildRole.Arn'
+      Source: 
+        Type: CODEPIPELINE
+        BuildSpec: buildspec_secrets.yml
+
+  #### CodeBuild Project - Vulnerability Scanning ####
+  CodeBuildVulnProject:
+    DependsOn: CodeBuildRole
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: aws/codebuild/standard:6.0
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: FAIL_WHEN
+            Type: PLAINTEXT
+            Value: !Ref FailWhen
+          - Name: AWS_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: !Ref AWS::AccountId
+          - Name: IMAGE_REPO_NAME
+            Type: PLAINTEXT
+            Value: !Ref ScratchRepository
+          - Name: IMAGE_ARN
+            Type: PLAINTEXT
+            Value: !GetAtt ECRRepository.Arn
+          - Name: FUNCTION_ARN
+            Value: !GetAtt SendFindingsLambda.Arn
+      Name: !Join [ '-', [ !Ref ResourceName, 'scan', 'image'  ] ]
+      ServiceRole: !GetAtt 'CodeBuildRole.Arn'
+      Source: 
+        Type: CODEPIPELINE
+        BuildSpec: buildspec_vuln.yml
+      
+  #### CodeBuild Project - Publish Image ####
+
+  CodeBuildPublishProject:
+    DependsOn: CodeBuildRole
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: 'BUILD_GENERAL1_SMALL'
+        Image: aws/codebuild/docker:18.09.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: !Ref "AWS::AccountId"
+          - Name: IMAGE_REPO_NAME
+            Type: PLAINTEXT
+            Value: !Join [ '-', [ !Ref ResourceName, 'sample'  ] ]
+      Name: !Join [ '-', [ !Ref ResourceName, 'publish'  ] ]
+      ServiceRole: !GetAtt 'CodeBuildRole.Arn'
+      Source: 
+        Type: CODEPIPELINE
+        BuildSpec: buildspec_push.yml
+
+Outputs: {}


### PR DESCRIPTION
*Issue #, if available:*
#31 
*Description of changes:*

- Updated boto3 for python3.9
- Changed all lambda function runtimes to support 3.9
- Changed code build environment to a larger instance type for vulnerability scan stage
- Created send findings AWS Lambda function to AWS Security Hub to send Grype findings
- Created buildspec_vuln.yml 
- Made a minor change to all badges image link to remove the dependency on immutable referenced bucket name and region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
